### PR TITLE
v2 added adjudicator buttons to the interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ visualizer after it opens.
 `aapb-annenv-role-filler-binder/raw_annotation_iaa_assessment/non_match_iaa_result_finder.py` to obtain a `.csv` of the 
 frames/entries where the two annotators do not match completely. (Non-"1.0, 1.0, 1.0, 1.0" lines). 
 5. That list gives you the frames you can go to manually in the visualizer and do adjudication for. 
-6. Make decisions for the adjudication. (e.g. deciding which frame should be the first readable frame and 
+6. Go to the visualizer repo, download the two sets of annotations and the image sets, and run `py visualizer.py`.
+7. Make decisions for the adjudication. (e.g. deciding which frame should be the first readable frame and 
 which are duplicates. Spelling, *s, etc.)
 
 ### Discussing Automatic Adjudication

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RFB Annotation Visualizer 
 
-This tool provides an interface for qualitative analysis of the agreement between annotators within the Role-Filler Binding schema currently in development by the Brandeis CLAMS team. It is a basic GUI app using Python's Tk/Tcl toolkit to display frames and the relative annotations for those frames. This allows us to refine our understanding of edge cases and sources of disagreement, and improve both the RFB spec/guidelines and our evaluation metrics for this specification.
+This tool provides an interface for qualitative analysis of the agreement between annotators within the Role-Filler Binding schema currently in development by the Brandeis CLAMS team. It is a basic GUI app using Python's Tk/Tcl toolkit to display frames and the relative annotations for those frames. This allows us to refine our understanding of edge cases and sources of disagreement, and improve both the RFB spec/guidelines and our evaluation metrics for this specification.  
+See RFB Visualizer v2 Adjudication Buttons section below for adjudication process updates. 
 
 ## Requirements for Installation
 
@@ -17,6 +18,7 @@ The visualizer pulls its data from three local directories which are, by default
 - `./data` is the directory containing human (or machine) annotations in .json format. Each annotator instance should be in its own sub-directory, labeled by its ID. 
 - `./results` is the directory containing IAA metrics for these annotations, in text format. the results file should be a single csv which contains at least each frame ID for each GUID. 
 - `./images` is the directory containing still images of the frames. 
+  - [!Important] - add the image sets into the `./images`
 
 The app can be run with `$python3`, and these directories can be set using the `data_directory`, `agreement_directory`, and `image_directory` runtime arguments.
 
@@ -31,3 +33,49 @@ Other runtime arguments include:
 ## Next Steps
 
 This still needs some work. The original IAA calculation that this tool was built on was revealed to be flawed, so minor changes may be needed if the revised IAA ends up being formatted differently. I also want to improve the visual component with better formatting + a more intuitive way to view the frames along a timeline.
+
+
+
+# RFB Visualizer v2 Adjudication Buttons
+This is an update to the tool to add buttons that allow the manual adjudication process. 
+You will also need to run the IAA agreement code from 
+[RFB Annotation Env](https://github.com/clamsproject/aapb-annenv-role-filler-binder) repo. 
+For future repo managers, please consider integrating this repo(RFB_annotation_visualizer) into RFB Annotation Env.  
+
+Buttons added: 
+1. Open Annotator One - Opens the `.json` file for that frame for that annotator. Uses your default option for that filetype. 
+This lets you manually edit the files if needed. 
+2. Open Annotator Two
+3. Next Frame - (tested against first and last frames of videos)
+4. Previous Frame - (tested against first and last frames of videos)
+5. Replace Anno1 w Anno2 
+   1. This button copies Anno1's current annotation to your computer's clipboard in case you want to undo it. (You could comment this out)
+   2. Copies Anno2's annotation. 
+   3. Overwrites all of Anno1 file with Anno2.
+   4. Opens Anno1 file in your file editor. (You could comment this out)
+   5. The intention of this is that you will create an adjudicated raw from the first annotator, so set the first annotator
+      as the one you suspect will be the better set to reduce use of this button. 
+
+Note - the current update is rudimentary and has sizing/spacing issues for the window. Workaround: expand the window of the
+visualizer after it opens. 
+
+## How to Adjudicate
+1. Obtain the RFB raws from multiple annotators/server-storage. 
+2. Load the raws data into the Annotation Env for RFB to do Raw Annotation InterAnnotator Agreement Assessment.
+3. Run `aapb-annenv-role-filler-binder/raw_annotation_iaa_assessment/src/rfb_agreement.py` to obtain IAA results `.csv`.
+   1. Optionally, run `aapb-annenv-role-filler-binder/raw_annotation_iaa_assessment/src/ragreement_report.py`
+   to get a readable aggregated report. 
+4. Take the IAA results `.csv` from step3, and run 
+`aapb-annenv-role-filler-binder/raw_annotation_iaa_assessment/non_match_iaa_result_finder.py` to obtain a `.csv` of the 
+frames/entries where the two annotators do not match completely. (Non-"1.0, 1.0, 1.0, 1.0" lines). 
+5. That list gives you the frames you can go to manually in the visualizer and do adjudication for. 
+6. Make decisions for the adjudication. (e.g. deciding which frame should be the first readable frame and 
+which are duplicates. Spelling, *s, etc.)
+
+### Discussing Automatic Adjudication
+Manual Adjudication was done because the issues involved with deciding how to do an automated machine adjudication.
+One concept was to take r2 20007's data as a base, and then copy 20008 into it when 20008 differed. 
+However, a closer look into the r2 data revealed that we would still have to deal with concerns about which frame was the
+first frame, and how to automatically detect that, issues with other messy errors, and that sometimes moving in 20008 
+did not seem to increase the quality. 
+Therefore, automatic adjudication has issues that are, as of yet, unsolved. 

--- a/visualizer.py
+++ b/visualizer.py
@@ -281,8 +281,8 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--image_directory",
         help="file location of frame images",
-        default="./images/images-R2-fewshot-credits", 
-    ) #changed default
+        default="./images",
+    )
     parser.add_argument(
         "--anno_one", help="First annotator instance ID number", default=20007
     )

--- a/visualizer.py
+++ b/visualizer.py
@@ -3,11 +3,10 @@
 File: RFB Annotation Visualizer
 V: 2
 v1 Author: Dean Cahill
-v2: Added buttons Jeremy Huey
+v2 Added Adjudication buttons: Jeremy Huey
 
 Known Issues:
-1. (v1) Upon opening, first image won't load. Perhaps adding a self.load_annotations(None)
-    # Reload annotations for the new frame , may help
+1. (v1) Upon opening, first image won't load. Perhaps adding a self.load_annotations(None) may help
 2. (v2) You will need to resize the window frame because the grid alignments are not right with the added buttons.
 3. Need explanation/readme of how to use UI/buttons to adjudicate.
 
@@ -282,7 +281,8 @@ def parse_arguments() -> argparse.Namespace:
         "--image_directory",
         help="file location of frame images",
         default="./images",
-    )
+        # default="./images/images-R2-fewshot-credits",
+    ) #changed default
     parser.add_argument(
         "--anno_one", help="First annotator instance ID number", default=20007
     )

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,4 +1,23 @@
 # RFB Annotation Visualizer
+'''
+File: RFB Annotation Visualizer
+V: 2
+v1 Author: Dean Cahill
+v2: Added buttons Jeremy Huey
+
+Known Issues:
+1. (v1) Upon opening, first image won't load. Perhaps adding a self.load_annotations(None)
+    # Reload annotations for the new frame , may help
+2. (v2) You will need to resize the window frame because the grid alignments are not right with the added buttons.
+3. Need explanation/readme of how to use UI/buttons to adjudicate.
+
+How to use:
+(add usage here)
+For v2 button use to adjudicate, please note that the intent is to overwrite Annotator 1's files until you get
+a fully adjudicated set of annotations.
+
+'''
+
 
 # TODO: timeline of frames
 
@@ -9,12 +28,14 @@ import argparse
 import csv
 import os
 import json
+import subprocess
+import pyperclip
 
 from PIL import Image, ImageTk
 import tkinter as tk
 from tkinter import ttk
 from ttkthemes import ThemedTk
-
+import webbrowser
 
 # ====================================|
 # Visualizer
@@ -23,7 +44,7 @@ class Visualizer:
     def __init__(self, **params):
         self.window = ThemedTk(theme=params["theme"])
         self.window.title("RFB Annotation Visualizer")
-        self.window.geometry("1600x900")
+        self.window.geometry("1600x900") # problem: need to arrange these buttons into a better format.
 
         # Parameters
         self.agg_type = params["aggtype"]
@@ -56,6 +77,44 @@ class Visualizer:
         self.t1_label = tk.Label(self.annotations, text=f"instance ID: {self.anno_one}")
         self.t2_label = tk.Label(self.annotations, text=f"instance ID: {self.anno_two}")
         self.annotations.grid(row=10, column=3)
+
+        # Buttons for opening annotation files
+        self.open_anno_one_button = tk.Button(
+            master=self.window,
+            text="Open Annotator One",
+            command=lambda: self.open_annotation_file(self.anno_one)
+        )
+        self.open_anno_one_button.grid(row=3, column=0, padx=5, pady=5)
+        self.open_anno_two_button = tk.Button(
+            master=self.window,
+            text="Open Annotator Two",
+            command=lambda: self.open_annotation_file(self.anno_two)
+        )
+        self.open_anno_two_button.grid(row=3, column=1, padx=5, pady=5)
+
+        # Button for moving to next frame
+        self.next_frame_button = tk.Button(
+            master=self.window,
+            text="Next Frame",
+            command=self.next_frame
+        )
+        self.next_frame_button.grid(row=4, column=0, padx=5, pady=5)
+
+        # Button for moving to prev frame
+        self.prev_frame_button = tk.Button(
+            master=self.window,
+            text="Prev Frame",
+            command=self.prev_frame
+        )
+        self.prev_frame_button.grid(row=4, column=1, padx=5, pady=5)
+
+        # Button for replacing and opening annotation file
+        self.replace_anno1_and_open_button = tk.Button(
+            master=self.window,
+            text="Replace Anno1 w Anno2",
+            command=self.replace_and_open_files
+        )
+        self.replace_anno1_and_open_button.grid(row=5, column=0, padx=5, pady=5)
 
     # =====================|
     # Getters
@@ -152,6 +211,52 @@ class Visualizer:
         image.image = pic
         image.grid(row=2, column=0)
 
+    # =====================|
+    # Button Event Helpers (added v2)
+    # =====================|
+    # Callback function for replacing and opening annotation files
+    def replace_and_open_files(self):
+        guid = self.guid_dropdown.get()
+        frame_num = self.frame_dropdown.get()
+        anno_one_file = f"{self.annotator_dir}/{self.anno_one}/{guid}.{frame_num}.json"
+        anno_two_file = f"{self.annotator_dir}/{self.anno_two}/{guid}.{frame_num}.json"
+        # Read contents of annotator two's file
+        with open(anno_two_file, 'r') as f:
+            content = f.read()
+        # Replace contents of annotator one's file with annotator two's file
+        with open(anno_one_file, 'r') as f:
+            old_content = f.read()
+            pyperclip.copy(old_content)  # make a copy of the old content from anno1 to your clipboard, in case
+        with open(anno_one_file, 'w') as f:
+            f.write(content)
+        # Open annotator one's file
+        webbrowser.open(anno_one_file)  # Open file using default application
+        # COMMENT ^ THIS ABOVE LINE if don't want to see it; to be faster!
+
+    # Callback function for moving to next frame
+    def next_frame(self):
+        current_index = self.frame_dropdown.current()
+        if current_index < len(self.frame_dropdown["values"]) - 1:
+            self.frame_dropdown.current(current_index + 1)
+            self.load_annotations(None)  # Reload annotations for the new frame
+
+    # Callback function for moving to prev frame
+    def prev_frame(self):
+        current_index = self.frame_dropdown.current()
+        if current_index > 0:
+            self.frame_dropdown.current(current_index - 1)
+            self.load_annotations(None)  # Reload annotations for the new frame
+
+    # Callback function to open annotation file
+    def open_annotation_file(self, annotator):
+        guid = self.guid_dropdown.get()
+        frame_num = self.frame_dropdown.get()
+        annotation_file_path = f"{self.annotator_dir}/{annotator}/{guid}.{frame_num}.json"
+        webbrowser.open(annotation_file_path)  # Open file using default application # THIS WORKED!
+        # os.system(f"notepad.exe {annotation_file_path}")  # Open file using Notepad
+        # subprocess.Popen(["notepad.exe", annotation_file_path])  # Open file using Notepad
+        # os.system(f"start {annotation_file_path}")  # Open file using default application # this did not
+
 
 # ====================================|
 # Main
@@ -176,8 +281,8 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--image_directory",
         help="file location of frame images",
-        default="./images",
-    )
+        default="./images/images-R2-fewshot-credits", 
+    ) #changed default
     parser.add_argument(
         "--anno_one", help="First annotator instance ID number", default=20007
     )


### PR DESCRIPTION
This update creates buttons in the visualizer interface that navigate frames and allow for opening annotation files and copying anno2 into anno1 for fast adjudication. Part of a needed tool to do manual adjud faster. 

Readme explain adjud process, which requires this tool. 
